### PR TITLE
Add AngryScanner IP docs, update PhotonLib docs, reorganize hardware docs, add known issues page

### DIFF
--- a/source/docs/getting-started/installation/coprocessor-image.rst
+++ b/source/docs/getting-started/installation/coprocessor-image.rst
@@ -18,6 +18,10 @@ Final Steps
 ^^^^^^^^^^^
 Simply insert the flashed microSD card into your Raspberry Pi and boot it up. After the initial setup process, your Raspberry Pi should be configured for PhotonVision. You can verify this by making sure your Raspberry Pi and computer are connected to the same network and navigating to ``photonvision.local:5800`` in your browser on your computer.
 
+Troubleshooting
+^^^^^^^^^^^^^^^
+If ``photonvision.local:5800`` does not resolve, your mDNS is not set up correctly. To fix this, download `Angry IP Scanner <https://angryip.org/download/#windows>`_ to find PhotonVision/your coprocessor on your network. Once you find it, set the IP to your static IP in PhotonVision. If you continue to have issues, do not hesistate to :ref:`contact us. <index:Contact Us>`
+
 Other Debian-Based Co-Processor Installation
 --------------------------------------------
 We provide an `install script <https://git.io/JJrEP>`_ for other Debian-based systems (with ``apt``) that will automatically install PhotonVision and make sure that it runs on startup.

--- a/source/docs/hardware.rst
+++ b/source/docs/hardware.rst
@@ -9,13 +9,13 @@ Supported Cameras
 * Pi Camera Module V1 and V2
 
   * The V1 is strongly preferred over the V2 due to the V2 having undesireable FOV choices.
-  
+
 * USB Cameras
- 
+
   * Reccomended: MicrosoftLifeCam HD-3000 (avaliable from AndyMark)
 
   * Most Logitech cameras (specifically the Logitech C270 HD Webcam (PN: 960-000694)) will not work with PhotonVision. The PS3ye needs a workaround to be usable, for more information see :ref:`our Known Issues page <docs/other/known-issues:Hardware Issues>`
-  
+
 * ELP Cameras
 
 Supported Coprocessors

--- a/source/docs/hardware.rst
+++ b/source/docs/hardware.rst
@@ -1,16 +1,44 @@
 Hardware
 ========
 
+Supported Hardware
+------------------
+
 Supported Cameras
------------------
+^^^^^^^^^^^^^^^^^
+* Pi Camera Module V1 and V2
 
-We support any USB camera, however, Logitech cameras don't work well with PhotonVision. We recommend the Microsoft LifeCam HD-3000 Camera, which is available from Andymark. The Raspberry Pi Camera Module V1 and V2 are supported with a supported Rasberry Pi. Additionally, ELP webcam modules are also recommended which can be found on Amazon, Ebay, Alibaba, or many other online sources.
+  * The V1 is strongly preferred over the V2 due to the V2 having undesireable FOV choices.
+  
+* USB Cameras
+ 
+  * Reccomended: MicrosoftLifeCam HD-3000 (avaliable from AndyMark)
 
-.. warning:: The Logitech C270 HD Webcam (PN: 960-000694) will not work with PhotonVision.
-
+  * Most Logitech cameras (specifically the Logitech C270 HD Webcam (PN: 960-000694)) will not work with PhotonVision. The PS3ye needs a workaround to be usable, for more information see :ref:`our Known Issues page <docs/other/known-issues:Hardware Issues>`
+  
+* ELP Cameras
 
 Supported Coprocessors
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
+* Raspberry Pi 3 (any version)
+* Raspberry Pi 4 (any version)
+
+Reccomended Hardware Combinations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The following combinations are ranked from best to worst:
+
+1. Raspberry Pi 3 with Pi Camera
+2. Raspberry Pi 4 with Pi Camera
+3. Raspberry Pi 4 with USB Camera
+4. Raspberry Pi 3 with USB Camera
+
+GPU Acceleration
+^^^^^^^^^^^^^^^^
+PhotonVision uses GPU Acceleration in order to maximize processing performance, however it is only supported on the Rasperry Pi 3, which is why it is reccomended over the Pi 4. For the technical information on why it is not supported on the Raspberry Pi 4, please see `here. <https://www.chiefdelphi.com/t/announcing-gloworm-an-inexpensive-and-open-source-vision-module/386370/61?u=pietroglyph>`_
+
+
+Support Levels
+--------------
 .. list-table::
    :widths: 15 30 45
    :header-rows: 1
@@ -23,7 +51,7 @@ Supported Coprocessors
          * All features will work
          * Everything will be kept up to date
      -   * Gloworm
-         * Raspberry Pi 3 and Raspberry Pi 4 with the official Pi image with the Pi Cam, PS3ye, or the Microsoft LifeCam3000
+         * Raspberry Pi 3 and Raspberry Pi 4 with the official Pi image with the Pi Cam or USB Cameras
    * - Compatible
      -   * No guarantee of support on Discord
          * Major features will work

--- a/source/docs/hardware.rst
+++ b/source/docs/hardware.rst
@@ -12,9 +12,9 @@ Supported Cameras
 
 * USB Cameras
 
-  * Reccomended: MicrosoftLifeCam HD-3000 (avaliable from AndyMark)
+  * Recomended: Microsoft LifeCam HD-3000 (available from AndyMark)
 
-  * Most Logitech cameras (specifically the Logitech C270 HD Webcam (PN: 960-000694)) will not work with PhotonVision. The PS3ye needs a workaround to be usable, for more information see :ref:`our Known Issues page <docs/other/known-issues:Hardware Issues>`
+  * Most Logitech cameras (specifically the Logitech C270 HD Webcam (PN: 960-000694)) will not work with PhotonVision. The PS3Eye needs a workaround to be usable, for more information see :ref:`our Known Issues page <docs/other/known-issues:Hardware Issues>`
 
 * ELP Cameras
 

--- a/source/docs/other/index.rst
+++ b/source/docs/other/index.rst
@@ -4,3 +4,5 @@ Other
 .. toctree::
 
    contributing/index
+   known-issues
+

--- a/source/docs/other/known-issues.rst
+++ b/source/docs/other/known-issues.rst
@@ -1,0 +1,12 @@
+Known Issues
+============
+
+Hardware Issues
+---------------
+
+PS3ye
+^^^^^
+Due to an issue with Linux kernels, the drivers for the PS3ye are no longer supported. If you would still like to use the PS3ye, you can downgrade your kernel with the following command: ``sudo CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt rpi-update 866751bfd023e72bd96a8225cf567e03c334ecc4``. Note: You must be connected to the internet to run the command.
+
+Software Issues
+---------------

--- a/source/docs/other/known-issues.rst
+++ b/source/docs/other/known-issues.rst
@@ -4,9 +4,9 @@ Known Issues
 Hardware Issues
 ---------------
 
-PS3ye
+PS3Eye
 ^^^^^
-Due to an issue with Linux kernels, the drivers for the PS3ye are no longer supported. If you would still like to use the PS3ye, you can downgrade your kernel with the following command: ``sudo CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt rpi-update 866751bfd023e72bd96a8225cf567e03c334ecc4``. Note: You must be connected to the internet to run the command.
+Due to an issue with Linux kernels, the drivers for the PS3Eye are no longer supported. If you would still like to use the PS3Eye, you can downgrade your kernel with the following command: ``sudo CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt rpi-update 866751bfd023e72bd96a8225cf567e03c334ecc4``. Note: You must be connected to the internet to run the command.
 
 Software Issues
 ---------------

--- a/source/docs/other/known-issues.rst
+++ b/source/docs/other/known-issues.rst
@@ -5,7 +5,7 @@ Hardware Issues
 ---------------
 
 PS3Eye
-^^^^^
+^^^^^^
 Due to an issue with Linux kernels, the drivers for the PS3Eye are no longer supported. If you would still like to use the PS3Eye, you can downgrade your kernel with the following command: ``sudo CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt rpi-update 866751bfd023e72bd96a8225cf567e03c334ecc4``. Note: You must be connected to the internet to run the command.
 
 Software Issues

--- a/source/docs/programming/photonlib/creating-photon-camera.rst
+++ b/source/docs/programming/photonlib/creating-photon-camera.rst
@@ -39,7 +39,7 @@ Use the ``getLatestResult()``/``GetLatestResult()`` (Java and C++ respectively) 
       // Get the latest pipeline result.
       photonlib::PhotonPipelineResult result = camera.GetLatestResult();
 
-.. note:: Unlike other vision software solutions, using the latest result guarantees that all information is from the same timestamp. This is achieveable because the PhotonVision backend sends a byte-packed string of data which is then deserialized by PhotonLib to get target data. For more information, check out the `PhotonLib source code <https://github.com/PhotonVision/photonlib>`_.
+.. note:: Unlike other vision software solutions, using the latest result guarantees that all information is from the same timestamp. This is achieveable because the PhotonVision backend sends a byte-packed string of data which is then deserialized by PhotonLib to get target data. For more information, check out the `PhotonLib source code <https://github.com/PhotonVision/photonvision/tree/master/photon-lib>`_.
 
 Saving Pictures to File
 -----------------------

--- a/source/docs/programming/photonlib/creating-photon-camera.rst
+++ b/source/docs/programming/photonlib/creating-photon-camera.rst
@@ -22,42 +22,24 @@ The ``PhotonCamera`` class has two constructors: one that takes a ``NetworkTable
       // Creates a new PhotonCamera.
       photonlib::PhotonCamera camera{"MyCamera"};
 
+.. warning:: Teams must have unique names for all of their cameras regardless of which coprocessor they are attached to.
 
-Checking for Existence of Targets
----------------------------------
-``PhotonCamera`` has a ``hasTargets()/HasTargets()`` method (Java and C++ respectively) that users can utilize to check if their vision system is detecting any targets.
-
-.. tabs::
-   .. code-tab:: java
-
-      // Check if there are any targets.
-      boolean targets = camera.hasTargets();
-
-   .. code-tab:: c++
-
-      // Check if there are any targets.
-      bool targets = camera.HasTargets();
-
-Getting Yaw, Pitch, and Area
-----------------------------
-``PhotonCamera`` contains three convenience methods for retrieving the yaw, pitch, and area of the best target. These methods are ``getBestTargetYaw()``/``GetBestTargetYaw()``, ``getBestTargetPitch()``/``GetBestTargetPitch()``, and ``getBestTargetArea()``/``GetBestTargetArea()`` for Java and C++ respectively.
+Getting the Pipeline Result
+---------------------------
+Use the ``getLatestResult()``/``GetLatestResult()`` (Java and C++ respectively) to obtain the latest :ref:`pipeline result <docs/programming/photonlib/simple-pipeline-result:Photon Pipeline Result>`. An advantage of using this method is that it returns a container with information that is guaranteed to be from the same timestamp. This is important if you are using this data for latency compensation or in an estimator.
 
 .. tabs::
    .. code-tab:: java
 
-      // Get the yaw, pitch, and area from the camera.
-      double yaw = camera.getBestTargetYaw();
-      double pitch = camera.getBestTargetPitch();
-      double area = camera.getBestTargetArea();
+      // Get the latest pipeline result.
+      PhotonPipelineResult result = camera.getLatestResult();
 
    .. code-tab:: c++
 
-      // Get the yaw, pitch, and area from the camera.
-      double yaw = camera.GetBestTargetYaw();
-      double pitch = camera.GetBestTargetPitch();
-      double area = camera.GetBestTargetArea();
+      // Get the latest pipeline result.
+      photonlib::PhotonPipelineResult result = camera.GetLatestResult();
 
-.. note:: The units for yaw and pitch are degrees and use standard computer vision directionality. Therefore, a negative yaw means that the recognized target is to the left of the center of the screen and a negative pitch means that the recognized target is below the center of the screen. Furthermore, area is scaled from 0-100, representing the percentage of the screen taken up by the bounding box.
+.. note:: Unlike other vision software solutions, using the latest result guarantees that all information is from the same timestamp. This is achieveable because the PhotonVision backend sends a byte-packed string of data which is then deserialized by PhotonLib to get target data. For more information, check out the `PhotonLib source code <https://github.com/PhotonVision/photonlib>`_.
 
 Saving Pictures to File
 -----------------------
@@ -86,19 +68,4 @@ Images are stored within the photonvision configuration directory. Running the "
 .. note:: Saving images to file takes a bit of time and uses up disk space, so doing it frequently is not recommended. In general, the camera will save an image every 500ms. Calling these methods faster will not result in additional images. Consider tying image captures to a button press on the driver controller, or an appropriate point in an autonomous routine.
 
 
-Getting the Pipeline Result (Advanced)
---------------------------------------
-One can also use the ``getLatestResult()``/``GetLatestResult()`` (Java and C++ respectively) to obtain the latest :ref:`pipeline result <docs/programming/photonlib/simple-pipeline-result:Photon Pipeline Result>`. An advantage of using this method is that it returns a container with information that is guaranteed to be from the same timestamp. This is important if you are using this data for latency compensation or in an estimator.
 
-.. tabs::
-   .. code-tab:: java
-
-      // Get the latest pipeline result.
-      PhotonPipelineResult result = camera.getLatestResult();
-
-   .. code-tab:: c++
-
-      // Get the latest pipeline result.
-      photonlib::PhotonPipelineResult result = camera.GetLatestResult();
-
-.. note:: Unlike other vision software solutions, using the latest result guarantees that all information is from the same timestamp. This is achieveable because the PhotonVision backend sends a byte-packed string of data which is then deserialized by PhotonLib to get target data. For more information, check out the `PhotonLib source code <https://github.com/PhotonVision/photonlib>`_.

--- a/source/docs/programming/photonlib/simple-pipeline-result.rst
+++ b/source/docs/programming/photonlib/simple-pipeline-result.rst
@@ -4,7 +4,7 @@ Photon Pipeline Result
 What is a Photon Pipeline Result?
 ---------------------------------
 
-A ``PhotonPipelineResult`` is a container that contains all information about currently detected targets from a ``PhotonCamera``. You can :ref:`retrieve the latest pipeline result <docs/programming/photonlib/creating-photon-camera:Getting the Pipeline Result (Advanced)>` using the ``getLatestResult()``/``GetLatestResult()`` (Java and C++ respectively) on a ``PhotonCamera`` instance.
+A ``PhotonPipelineResult`` is a container that contains all information about currently detected targets from a ``PhotonCamera``. You can :ref:`retrieve the latest pipeline result <docs/programming/photonlib/creating-photon-camera:Getting the Pipeline Result>` using the ``getLatestResult()``/``GetLatestResult()`` (Java and C++ respectively) on a ``PhotonCamera`` instance.
 
 Checking for Existence of Targets
 ---------------------------------
@@ -24,7 +24,7 @@ Each pipeline result has a ``hasTargets()``/``HasTargets()`` (Java and C++ respe
 
 Getting a List of Targets
 -------------------------
-You can get a list of :ref:`tracked targets <docs/programming/photonlib/simple-tracked-target:Photon Tracked Target>` using the ``getTargets()``/``GetTargets()`` (Java and C++ respectively) method from a pipeline result.
+You can get a list of :ref:`tracked targets <docs/programming/photonlib/simple-tracked-target:What is a Photon Tracked Target?>` using the ``getTargets()``/``GetTargets()`` (Java and C++ respectively) method from a pipeline result.
 
 .. tabs::
    .. code-tab:: java
@@ -36,6 +36,21 @@ You can get a list of :ref:`tracked targets <docs/programming/photonlib/simple-t
 
       // Get a list of currently tracked targets.
       wpi::ArrayRef<photonlib::PhotonTrackedTarget> targets = result.GetTargets();
+
+Getting the Best Target
+-----------------------
+You can get the :ref:`best target <docs/getting-started/pipeline-tuning/contour-filtering:Contour Grouping and Sorting>` using ``getBestTarget()``/``GetBestTarget()`` (Java and C++ respectively) method from the pipeline result.
+
+.. tabs::
+   .. code-tab:: java
+
+      // Get the current best target.
+      PhotonTrackedTarget target = result.getBestTarget();
+
+   .. code-tab:: c++
+
+      // Get a list of currently tracked targets.
+      photonlib::PhotonTrackedTarget target = result.GetBestTarget();
 
 Getting the Pipeline Latency
 ----------------------------

--- a/source/docs/programming/photonlib/util-calculations.rst
+++ b/source/docs/programming/photonlib/util-calculations.rst
@@ -4,7 +4,7 @@ A ``PhotonUtils`` class with helpful common calculations is included within ``Ph
 
 Calculating Distance to Target
 ------------------------------
-If your camera is at a fixed height on your robot and the height of the target is fixed, you can calculate the distance to the target based on your camera's pitch and the :ref:`pitch to the target <docs/programming/photonlib/creating-photon-camera:Getting Yaw, Pitch, and Area>`.
+If your camera is at a fixed height on your robot and the height of the target is fixed, you can calculate the distance to the target based on your camera's pitch and the :ref:`pitch to the target <docs/programming/photonlib/simple-tracked-target:Retrieving Data from a Photon Tracked Target>`.
 
 .. tabs::
    .. code-tab:: java


### PR DESCRIPTION
This should be everything, please check over the PhotonLib parts closely as I deleted a few sections (to make it more clear to the user that they should be going from PipelineResult to TrackedTarget and then getting Yaw, Pitch, etc. unlike before where they got it from a PhotonCamera method.

Hardware documentation still isn't optimal yet in terms of organization but at least it still has all the information that we need.

Known issues page documents PS3ye stuff and has an empty software section