### PR TITLE
Add sphinx_rtd_theme to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ doc8==0.8.1
 sphinxcontrib-ghcontributors==0.2.2
 sphinx-notfound-page==0.5
 sphinxcontrib-remoteliteralinclude==0.0.4
-pip install sphinx-rtd-theme
+sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ doc8==0.8.1
 sphinxcontrib-ghcontributors==0.2.2
 sphinx-notfound-page==0.5
 sphinxcontrib-remoteliteralinclude==0.0.4
+pip install sphinx-rtd-theme


### PR DESCRIPTION
I needed to install it after running `pip install -r requirements.txt` in order to build successfully.