### PR TITLE
Fixes broken link on settings page

### DIFF
--- a/source/docs/getting-started/Settings.rst
+++ b/source/docs/getting-started/Settings.rst
@@ -9,7 +9,7 @@ Here, you can view general data on your system, including version, hardware, you
 
 Networking
 ^^^^^^^^^^
-Here, you can set your team number (note: you must always do this if using PhotonVision on a robot), switch your IP between DCHP and static, and specify your host name. For instructions on how to properly set your static IP, please follow the steps `here <https://docs.photonvision.org/en/latest/docs/getting-started/installation/coprocessor-image.html?highlight=IP#troubleshooting>`_ and then fill in the proper field after you select static IP. For more information on networking, click `here. <https://docs.wpilib.org/en/latest/docs/networking/networking-introduction/networking-basics.html>`_
+Here, you can set your team number (note: you must always do this if using PhotonVision on a robot), switch your IP between DCHP and static, and specify your host name. For instructions on how to properly set your static IP, please follow the steps `here <https://docs.photonvision.org/en/latest/docs/getting-started/installation/coprocessor-image.html?highlight=IP#troubleshooting-setting-a-static-ip>`_ and then fill in the proper field after you select static IP. For more information on networking, click `here. <https://docs.wpilib.org/en/latest/docs/networking/networking-introduction/networking-basics.html>`_
 
 LEDs
 ^^^^


### PR DESCRIPTION
Changes:
https://docs.photonvision.org/en/latest/docs/getting-started/installation/coprocessor-image.html?highlight=IP#troubleshooting
 to 
https://docs.photonvision.org/en/latest/docs/getting-started/installation/coprocessor-image.html?highlight=IP#troubleshooting-setting-a-static-ip