### PR TITLE
Fix variable name in simulation docs

### DIFF
--- a/source/docs/programming/photonlib/simulation.rst
+++ b/source/docs/programming/photonlib/simulation.rst
@@ -49,7 +49,7 @@ It requires a number of pieces of configuration to accurately simulate your phys
         int camResolutionHeight = 480;    // pixels
         double minTargetArea = 10;        // square pixels
 
-        visionSys = new SimVisionSystem(camName,
+        simVision = new SimVisionSystem(camName,
                                         camDiagFOV,
                                         camPitch,
                                         cameraToRobot,


### PR DESCRIPTION
Per [Jason on discord](https://discord.com/channels/725836368059826228/725848198794706994/820278569233678367) - object name incorrect in Java in the instantiation block.