### PR TITLE
Update gloworm hostname to photonvision

### DIFF
--- a/source/docs/getting-started/installation/networking.rst
+++ b/source/docs/getting-started/installation/networking.rst
@@ -41,7 +41,7 @@ If you would like to access your Ethernet-connected vision device from a compute
 
         wpi::PortForwarder::GetInstance().Add(5800, "photonvision.local", 5800);
 
-.. note:: The address in the code above (``photonvision.local``) is the hostname of the coprocessor. This can be different depending on your hardware (ex. for the Gloworm it will be ``gloworm.local``)
+.. note:: The address in the code above (``photonvision.local``) is the hostname of the coprocessor. This can be different depending on your hardware, and can be checked in the settings tab under "hostname".
 
 Camera Stream Ports
 -------------------

--- a/source/docs/getting-started/installation/sw_install/gloworm.rst
+++ b/source/docs/getting-started/installation/sw_install/gloworm.rst
@@ -4,7 +4,7 @@ While not currently in production, PhotonVision still supports Gloworm vision pr
 
 Downloading the Gloworm Image
 -----------------------------
-Download the latest `Gloworm release of PhotonVision <https://github.com/gloworm-vision/pi-img-updator/releases>`_. You do not need to extract the downloaded ZIP file.
+Download the latest `Gloworm/Limelight release of PhotonVision <https://github.com/photonvision/photonvision/releases>`_; the image will be suffixed with "image_limelight.xz". You do not need to extract the downloaded archive.
 
 Flashing the Gloworm Image
 --------------------------
@@ -24,11 +24,11 @@ Final Steps
 -----------
 Power your device per its documentation and connect it to a robot network.
 
-You should be able to locate the camera at ``http://gloworm.local:5800/`` in your browser on your computer when connected to the robot.
+You should be able to locate the camera at ``http://photonvision.local:5800/`` in your browser on your computer when connected to the robot.
 
 Troubleshooting/Setting a Static IP
 -----------------------------------
-A static IP address may be used as an alternative to the mDNS ``gloworm.local`` address.
+A static IP address may be used as an alternative to the mDNS ``photonvision.local`` address.
 
 Download and run `Angry IP Scanner <https://angryip.org/download/#windows>`_ to find PhotonVision/your coprocessor on your network.
 

--- a/source/docs/getting-started/installation/sw_install/limelight.rst
+++ b/source/docs/getting-started/installation/sw_install/limelight.rst
@@ -18,7 +18,7 @@ Download the hardwareConfig.json file for the version of your Limelight:
 - :download:`Limelight Version 2 <files/Limelight2/hardwareConfig.json>`.
 - :download:`Limelight Version 2+ <files/Limelight2+/hardwareConfig.json>`.
 
-:ref:`Import the hardwareConfig.json file <docs/hardware/config:Importing and Exporting Settings>`. Again, this is **REQUIRED** or target measurements will be incorrect.
+:ref:`Import the hardwareConfig.json file <docs/hardware/config:Importing and Exporting Settings>`. Again, this is **REQUIRED** or target measurements will be incorrect, and LEDs will not work.
 
-After installation you should be able to `locate the camera <https://web.archive.org/web/20220525051734/https://gloworm.vision//docs/quickstart/#finding-gloworm>`_ at: ``http://gloworm.local:5800/``
+After installation you should be able to `locate the camera <https://web.archive.org/web/20220525051734/https://gloworm.vision//docs/quickstart/#finding-gloworm>`_ at: ``http://photonvision.local:5800/`` (not ``gloworm.local``, as previously)
 


### PR DESCRIPTION
In the latest Photon release, the hostname has changed to photonvision.local