### PR TITLE
Orange Pi 5 docs

### DIFF
--- a/source/docs/getting-started/installation/sw_install/orange-pi.rst
+++ b/source/docs/getting-started/installation/sw_install/orange-pi.rst
@@ -1,9 +1,11 @@
 Orange Pi Installation
 ======================
 
-Downloading Armbian Bullseye CLI
---------------------------------
-Download the latest release of the Armbian Bullseye CLI image from `here <https://redirect.armbian.com/region/NA/orangepi4-lts/Bullseye_current>`_.
+Downloading Linux Image
+-----------------------
+For an Orange Pi 4, download the latest release of the Armbian Bullseye CLI image from `here <https://redirect.armbian.com/region/NA/orangepi4-lts/Bullseye_current>`_.
+
+For an Orange Pi 5, download the latest release of either Debian Bullseye or Ubuntu Jammy (22.04). For both, you should get the "server" version. You can get the images from the `Orange Pi website <http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/service-and-support/Orange-pi-5.html>`_.
 
 
 Flashing the Pi Image
@@ -12,15 +14,19 @@ An 8GB or larger SD card is recommended.
 
 Use `Balena Etcher <https://www.balena.io/etcher/>`_ to flash an image onto a Orange Pi. Select the downloaded ``.zip`` file, select your microSD card, and flash.
 
+The Orange Pi 5 images from Orange Pi are compressed with 7Zip (extension ".7z"), and you will need to extract the image first.
+
 For more detailed instructions on using Etcher, please see the `Etcher website <https://www.balena.io/etcher/>`_.
 
-.. warning:: Using an older version of Balena Etcher may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to the latest Balena Etcher will fix this issue.
+.. warning:: Using an older version of Balena Etcher may cause bootlooping (the system will repeatedly boot and restart) when imaging your Orange Pi. Updating to the latest Balena Etcher will fix this issue.
+
+.. note:: If you are working on Linux, "dd" can be used in the command line to flash an image.
 
 Initial Setup
 -------------
 Insert the flashed microSD card into your Orange Pi and boot it up. The first boot may take a few minutes as the Pi expands the filesystem. Be sure not to unplug during this process.
 
-Plug your Orange Pi into a display via HDMI and plug in a keyboard via USB once its powered up. Complete the initial set up which involves creating a root password and adding a user, as well as setting localization language. Additionally, choose “bash” when prompted.
+Plug your Orange Pi into a display via HDMI and plug in a keyboard via USB once its powered up. For an Orange Pi 4, complete the initial set up which involves creating a root password and adding a user, as well as setting localization language. Additionally, choose “bash” when prompted.
 
 Installing PhotonVision
 -----------------------

--- a/source/docs/getting-started/installation/sw_install/other-coprocessors.rst
+++ b/source/docs/getting-started/installation/sw_install/other-coprocessors.rst
@@ -26,14 +26,11 @@ Updating PhotonVision
 
 PhotonVision can be updated by stopping the service, copying in the updated jar, and restarting the service.
 
-For example, from another Linux computer, run the following:
+For example, from another computer, run the following commands. Substitute the correct username for "[user]" (e.g. Raspberry Pi uses "pi", Orange Pi uses "orangepi".)
 
 .. code-block:: bash
 
-   $ scp [jar name].jar pi@photonvision.local:~/
-   $ ssh pi@photonvision.local
-   $ sudo systemctl stop photonvision.service
+   $ scp [jar name].jar [user]@photonvision.local:~/
+   $ ssh [user]@photonvision.local
    $ sudo mv [jar name].jar /opt/photonvision/photonvision.jar
-   $ sudo systemctl start photonvision.service
-
-
+   $ sudo systemctl restart photonvision.service


### PR DESCRIPTION
The Orange Pi instructions were morre specificly for a OPi4. I added some details for an OPi5, at least based on what I did. I also cleaned out a bit of RPi based stuff from the General Processor page (only RPi uses "pi" as a username).