### PR TITLE
Correct Typo & initialize AprilTagFieldLayout correctly

### DIFF
--- a/source/docs/programming/photonlib/robot-pose-estimator.rst
+++ b/source/docs/programming/photonlib/robot-pose-estimator.rst
@@ -15,7 +15,7 @@ The API documentation can be found in here: `Java <https://github.wpilib.org/all
    .. code-block:: java
 
       // The parameter for loadFromResource() will be different depending on the game.
-      AprilTagFieldLayout aprilTagFieldLayout = new AprilTagFieldLayout(AprilTagFieldLayout.loadFromResource(AprilTagFields.k2022RapidReact.m_resourceFile));
+      AprilTagFieldLayout aprilTagFieldLayout = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2023ChargedUp.m_resourceFile);
 
    .. code-block:: c++
 

--- a/source/docs/programming/photonlib/robot-pose-estimator.rst
+++ b/source/docs/programming/photonlib/robot-pose-estimator.rst
@@ -15,7 +15,7 @@ The API documentation can be found in here: `Java <https://github.wpilib.org/all
    .. code-block:: java
 
       // The parameter for loadFromResource() will be different depending on the game.
-      AprilTagFieldLayout aprilTagFieldLayout = new ApriltagFieldLayout(AprilTagFieldLayout.loadFromResource(AprilTagFields.k2022RapidReact.m_resourceFile));
+      AprilTagFieldLayout aprilTagFieldLayout = new AprilTagFieldLayout(AprilTagFieldLayout.loadFromResource(AprilTagFields.k2022RapidReact.m_resourceFile));
 
    .. code-block:: c++
 


### PR DESCRIPTION
`AprilTagFieldLayout.loadFromResource` returns an `AprilTagFieldLayout` meaning passing it back into the constructor is not needed and also a syntax error as `AprilTagFieldLayout` has no defined constructor for `AprilTagFieldLayout(AprilTagFieldLayout))`