### PR TITLE
Java example returned type is incorrect in example. (page: using-target-data)

### DIFF
--- a/source/docs/programming/photonlib/using-target-data.rst
+++ b/source/docs/programming/photonlib/using-target-data.rst
@@ -11,7 +11,7 @@ Estimating Field Relative Pose with AprilTags
    .. code-block:: java
 
       // Calculate robot's field relative pose
-      Pose3D robotPose = PhotonUtils.estimateFieldToRobotAprilTag(target.getBestCameraToTarget(), aprilTagFieldLayout.getTagPose(target.getFiducialId()), cameraToRobot);
+      Pose3d robotPose = PhotonUtils.estimateFieldToRobotAprilTag(target.getBestCameraToTarget(), aprilTagFieldLayout.getTagPose(target.getFiducialId()), cameraToRobot);
    .. code-block:: c++
 
      //TODO


### PR DESCRIPTION
on the page: using-target-data

the description correctly states that "``estimateFieldToRobotAprilTag(...)`` returns your robot’s Pose3d" however the example shows the function returning a Pose3D instead. Likely a caps typo.

I have fixed the example so that it shows the correct return type.