### PR TITLE
Use the 2024 Apriltag Field Layout instead of 2023

### DIFF
--- a/source/docs/programming/photonlib/robot-pose-estimator.rst
+++ b/source/docs/programming/photonlib/robot-pose-estimator.rst
@@ -15,7 +15,7 @@ The API documentation can be found in here: `Java <https://github.wpilib.org/all
    .. code-block:: java
 
       // The parameter for loadFromResource() will be different depending on the game.
-      AprilTagFieldLayout aprilTagFieldLayout = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2023ChargedUp.m_resourceFile);
+      AprilTagFieldLayout aprilTagFieldLayout = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2024Crescendo.m_resourceFile);
 
    .. code-block:: c++
 

--- a/source/docs/simulation/simulation.rst
+++ b/source/docs/simulation/simulation.rst
@@ -96,7 +96,7 @@ For convenience, an ``AprilTagFieldLayout`` can also be added to automatically c
    .. code-block:: java
 
       // The layout of AprilTags which we want to add to the vision system
-      AprilTagFieldLayout tagLayout = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2023ChargedUp.m_resourceFile);
+      AprilTagFieldLayout tagLayout = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2024Crescendo.m_resourceFile);
 
       visionSim.addAprilTags(tagLayout);
 


### PR DESCRIPTION
more of a subjective change, but will make writing vision code for 2024 easier. 

I changed all references of ``AprilTagFields.k2023ChargedUp`` to ``AprilTagFields.k2024Crescendo``