### PR TITLE
Photonlibpy Docs - getBestTarget

### DIFF
--- a/source/docs/programming/photonlib/getting-target-data.rst
+++ b/source/docs/programming/photonlib/getting-target-data.rst
@@ -128,7 +128,8 @@ You can get the :ref:`best target <docs/reflectiveAndShape/contour-filtering:Con
 
    .. code-block:: python
 
-      # TODO - Not currently supported
+      # Get the current best target.
+      target = result.getBestTarget()
 
 
 Getting Data From A Target


### PR DESCRIPTION
Related to the [feature addition at the main PhotonVision repository (#1223)](https://github.com/PhotonVision/photonvision/pull/1223). That one should be merged before this one.

Add usage of `getBestTarget` from a result.