### PR TITLE
Add Import/Export Settings steps for competitions under `Best Practices`

### DIFF
--- a/source/docs/additional-resources/best-practices.rst
+++ b/source/docs/additional-resources/best-practices.rst
@@ -21,6 +21,12 @@ During the Competition
     * Move the robot close, far, angled, and around the field to ensure no extra targets are found anywhere when looking for a target.
     * Go to a practice match to ensure everything is working correctly.
 
+* After field calibration, use the "Export Settings" button in the "Settings" page to create a backup.
+    * Do this for each coprocessor on your robot that runs PhotonVision, and name your exports with meaningful names.
+    * This will contain camera information/calibration, pipeline information, network settings, etc.
+    * In the event of software/hardware failures (IE lost SD Card, broken device), you can then use the "Import Settings" button and select "All Settings" to restore your settings.
+    * This effectively works as a snapshot of your PhotonVision data that can be restored at any point.
+
 * Before every match, check the ethernet connection going into your coprocessor and that it is seated fully.
 * Ensure that exposure is as low as possible and that you don't have the dashboard up when you don't need it to reduce bandwidth.
 * Stream at as low of a resolution as possible while still detecting targets to stay within bandwidth limits.


### PR DESCRIPTION
From a real story at competition:

We lost an SD Card during eliminations at our last competition, but thankfully remembered to create a snapshot of our settings using the built-in `Export Settings`/`Import Settings` tools on the Settings page. We were able to restore our OrangePi's functionality by following simple backup procedure. Hopefully this information can help other teams as well.