### PR TITLE
Update balena etcher references to point to 1.18.11 closes PhotonVision/photonvision-docs#357

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -118,3 +118,9 @@ html_theme_options = {
 suppress_warnings = ['epub.unknown_project_files']
 
 sphinx_tabs_valid_builders = ['epub', 'linkcheck']
+
+# Excluded links for linkcheck
+# These should be periodically checked by hand to ensure that they are still functional
+linkcheck_ignore = [
+'https://www.raspberrypi.com/software/'
+]

--- a/source/docs/hardware/picamconfig.rst
+++ b/source/docs/hardware/picamconfig.rst
@@ -52,4 +52,4 @@ Save the file, close the editor, and eject the drive. The boot configuration sho
 Additional Information
 ----------------------
 
-See `the libcamera documentation <https://github.com/raspberrypi/documentation/blob/679fab721855a3e8f17aa51819e5c2a7c447e98d/documentation/asciidoc/computers/camera/rpicam_configuration.adoc#L15>`_ for more details on configuring cameras.
+See `the libcamera documentation <https://github.com/raspberrypi/documentation/blob/679fab721855a3e8f17aa51819e5c2a7c447e98d/documentation/asciidoc/computers/camera/rpicam_configuration.adoc>`_ for more details on configuring cameras.

--- a/source/docs/hardware/picamconfig.rst
+++ b/source/docs/hardware/picamconfig.rst
@@ -52,4 +52,4 @@ Save the file, close the editor, and eject the drive. The boot configuration sho
 Additional Information
 ----------------------
 
-See `the libcamera documentation <https://github.com/raspberrypi/documentation/blob/develop/documentation/asciidoc/computers/camera/rpicam_apps_getting_started.adoc>`_ for more details on configuring cameras.
+See `the libcamera documentation <https://github.com/raspberrypi/documentation/blob/679fab721855a3e8f17aa51819e5c2a7c447e98d/documentation/asciidoc/computers/camera/rpicam_configuration.adoc#L15>`_ for more details on configuring cameras.

--- a/source/docs/installation/sw_install/gloworm.rst
+++ b/source/docs/installation/sw_install/gloworm.rst
@@ -18,7 +18,7 @@ Select the compute module. If it doesn't show up after 30s try using another USB
 
 Hit flash. Wait for flashing to complete, then disconnect your USB C cable.
 
-.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Gloworm. Updating to the latest Balena Etcher will fix this issue.
+.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Gloworm. Updating to 1.18.11 will fix this issue.
 
 Final Steps
 -----------

--- a/source/docs/installation/sw_install/gloworm.rst
+++ b/source/docs/installation/sw_install/gloworm.rst
@@ -10,7 +10,7 @@ Flashing the Gloworm Image
 --------------------------
 Plug a USB C cable from your computer into the USB C port on Gloworm labeled with a download icon.
 
-Use `Balena Etcher <https://www.balena.io/etcher/>`_ to flash an image onto the coprocessor.
+Use the 1.18.11 version of `Balena Etcher <https://github.com/balena-io/etcher/releases/tag/v1.18.11>`_ to flash an image onto the coprocessor.
 
 Run BalenaEtcher as an administrator. Select the downloaded ``.zip`` file.
 
@@ -18,7 +18,7 @@ Select the compute module. If it doesn't show up after 30s try using another USB
 
 Hit flash. Wait for flashing to complete, then disconnect your USB C cable.
 
-.. warning:: Using an older version of Balena Etcher may cause bootlooping (the system will repeatedly boot and restart) when imaging your Gloworm. Updating to the latest Balena Etcher will fix this issue.
+.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Gloworm. Updating to the latest Balena Etcher will fix this issue.
 
 Final Steps
 -----------

--- a/source/docs/installation/sw_install/orange-pi.rst
+++ b/source/docs/installation/sw_install/orange-pi.rst
@@ -12,11 +12,11 @@ Flashing the Pi Image
 ---------------------
 An 8GB or larger SD card is recommended.
 
-Use `Balena Etcher <https://www.balena.io/etcher/>`_ to flash an image onto a Orange Pi. Select the downloaded image file, select your microSD card, and flash.
+Use the 1.18.11 version of `Balena Etcher <https://github.com/balena-io/etcher/releases/tag/v1.18.11>`_ to flash an image onto a Orange Pi. Select the downloaded image file, select your microSD card, and flash.
 
 For more detailed instructions on using Etcher, please see the `Etcher website <https://www.balena.io/etcher/>`_.
 
-.. warning:: Using an older version of Balena Etcher may cause bootlooping (the system will repeatedly boot and restart) when imaging your Orange Pi. Updating to the latest Balena Etcher will fix this issue.
+.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Orange Pi. Updating to the latest Balena Etcher will fix this issue.
 
 .. note:: If you are working on Linux, "dd" can be used in the command line to flash an image.
 

--- a/source/docs/installation/sw_install/orange-pi.rst
+++ b/source/docs/installation/sw_install/orange-pi.rst
@@ -18,6 +18,10 @@ For more detailed instructions on using Etcher, please see the `Etcher website <
 
 .. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Orange Pi. Updating to 1.18.11 will fix this issue.
 
+Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.org/software/>`_ to flash the image. 
+
+Select "Choose OS" and then "Use custom" to select the downloaded image file. Select your microSD card and flash.
+
 .. note:: If you are working on Linux, "dd" can be used in the command line to flash an image.
 
 If you're using an Orange Pi 5, that's it! Orange Pi 4 users will need to install PhotonVision (see below).

--- a/source/docs/installation/sw_install/orange-pi.rst
+++ b/source/docs/installation/sw_install/orange-pi.rst
@@ -18,7 +18,7 @@ For more detailed instructions on using Etcher, please see the `Etcher website <
 
 .. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Orange Pi. Updating to 1.18.11 will fix this issue.
 
-Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.org/software/>`_ to flash the image. 
+Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.com/software/>`_ to flash the image. 
 
 Select "Choose OS" and then "Use custom" to select the downloaded image file. Select your microSD card and flash.
 

--- a/source/docs/installation/sw_install/orange-pi.rst
+++ b/source/docs/installation/sw_install/orange-pi.rst
@@ -18,7 +18,7 @@ For more detailed instructions on using Etcher, please see the `Etcher website <
 
 .. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Orange Pi. Updating to 1.18.11 will fix this issue.
 
-Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.com/software/>`_ to flash the image. 
+Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.com/software/>`_ to flash the image.
 
 Select "Choose OS" and then "Use custom" to select the downloaded image file. Select your microSD card and flash.
 

--- a/source/docs/installation/sw_install/orange-pi.rst
+++ b/source/docs/installation/sw_install/orange-pi.rst
@@ -16,7 +16,7 @@ Use the 1.18.11 version of `Balena Etcher <https://github.com/balena-io/etcher/r
 
 For more detailed instructions on using Etcher, please see the `Etcher website <https://www.balena.io/etcher/>`_.
 
-.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Orange Pi. Updating to the latest Balena Etcher will fix this issue.
+.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Orange Pi. Updating to 1.18.11 will fix this issue.
 
 .. note:: If you are working on Linux, "dd" can be used in the command line to flash an image.
 

--- a/source/docs/installation/sw_install/raspberry-pi.rst
+++ b/source/docs/installation/sw_install/raspberry-pi.rst
@@ -16,7 +16,7 @@ Use the 1.18.11 version of `Balena Etcher <https://github.com/balena-io/etcher/r
 
 For more detailed instructions on using Etcher, please see the `Etcher website <https://www.balena.io/etcher/>`_.
 
-.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to the latest Balena Etcher will fix this issue.
+.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to 1.18.11 will fix this issue.
 
 If you are using a non-standard Pi Camera connected to the CSI port, :ref:`additional configuration may be required. <docs/hardware/picamconfig:Pi Camera Configuration>`
 

--- a/source/docs/installation/sw_install/raspberry-pi.rst
+++ b/source/docs/installation/sw_install/raspberry-pi.rst
@@ -18,7 +18,7 @@ For more detailed instructions on using Etcher, please see the `Etcher website <
 
 .. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to 1.18.11 will fix this issue.
 
-Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.com/software/>`_ to flash the image. 
+Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.com/software/>`_ to flash the image.
 
 Select "Choose OS" and then "Use custom" to select the downloaded image file. Select your microSD card and flash.
 

--- a/source/docs/installation/sw_install/raspberry-pi.rst
+++ b/source/docs/installation/sw_install/raspberry-pi.rst
@@ -18,6 +18,10 @@ For more detailed instructions on using Etcher, please see the `Etcher website <
 
 .. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to 1.18.11 will fix this issue.
 
+Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.org/software/>`_ to flash the image. 
+
+Select "Choose OS" and then "Use custom" to select the downloaded image file. Select your microSD card and flash.
+
 If you are using a non-standard Pi Camera connected to the CSI port, :ref:`additional configuration may be required. <docs/hardware/picamconfig:Pi Camera Configuration>`
 
 Final Steps

--- a/source/docs/installation/sw_install/raspberry-pi.rst
+++ b/source/docs/installation/sw_install/raspberry-pi.rst
@@ -12,11 +12,11 @@ Flashing the Pi Image
 ---------------------
 An 8GB or larger card is recommended.
 
-Use `Balena Etcher <https://www.balena.io/etcher/>`_ to flash an image onto a Raspberry Pi. Select the downloaded ``.tar.xz`` file, select your microSD card, and flash.
+Use the 1.18.11 version of `Balena Etcher <https://github.com/balena-io/etcher/releases/tag/v1.18.11>`_ to flash an image onto a Raspberry Pi. Select the downloaded ``.tar.xz`` file, select your microSD card, and flash.
 
 For more detailed instructions on using Etcher, please see the `Etcher website <https://www.balena.io/etcher/>`_.
 
-.. warning:: Using an older version of Balena Etcher may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to the latest Balena Etcher will fix this issue.
+.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to the latest Balena Etcher will fix this issue.
 
 If you are using a non-standard Pi Camera connected to the CSI port, :ref:`additional configuration may be required. <docs/hardware/picamconfig:Pi Camera Configuration>`
 

--- a/source/docs/installation/sw_install/raspberry-pi.rst
+++ b/source/docs/installation/sw_install/raspberry-pi.rst
@@ -18,7 +18,7 @@ For more detailed instructions on using Etcher, please see the `Etcher website <
 
 .. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to 1.18.11 will fix this issue.
 
-Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.org/software/>`_ to flash the image. 
+Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.com/software/>`_ to flash the image. 
 
 Select "Choose OS" and then "Use custom" to select the downloaded image file. Select your microSD card and flash.
 

--- a/source/docs/installation/sw_install/snakeyes.rst
+++ b/source/docs/installation/sw_install/snakeyes.rst
@@ -10,11 +10,11 @@ Flashing the SnakeEyes Image
 ----------------------------
 An 8GB or larger card is recommended.
 
-Use `Balena Etcher <https://www.balena.io/etcher/>`_ to flash an image onto a Raspberry Pi. Select the downloaded ``.zip`` file, select your microSD card, and flash.
+Use the 1.18.11 version of `Balena Etcher <https://github.com/balena-io/etcher/releases/tag/v1.18.11>`_ to flash an image onto a Raspberry Pi. Select the downloaded ``.zip`` file, select your microSD card, and flash.
 
 For more detailed instructions on using Etcher, please see the `Etcher website <https://www.balena.io/etcher/>`_.
 
-.. warning:: Using an older version of Balena Etcher may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to the latest Balena Etcher will fix this issue.
+.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to the latest Balena Etcher will fix this issue.
 
 Final Steps
 -----------

--- a/source/docs/installation/sw_install/snakeyes.rst
+++ b/source/docs/installation/sw_install/snakeyes.rst
@@ -14,7 +14,7 @@ Use the 1.18.11 version of `Balena Etcher <https://github.com/balena-io/etcher/r
 
 For more detailed instructions on using Etcher, please see the `Etcher website <https://www.balena.io/etcher/>`_.
 
-.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to the latest Balena Etcher will fix this issue.
+.. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to 1.18.11 will fix this issue.
 
 Final Steps
 -----------

--- a/source/docs/installation/sw_install/snakeyes.rst
+++ b/source/docs/installation/sw_install/snakeyes.rst
@@ -16,7 +16,7 @@ For more detailed instructions on using Etcher, please see the `Etcher website <
 
 .. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to 1.18.11 will fix this issue.
 
-Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.org/software/>`_ to flash the image. 
+Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.com/software/>`_ to flash the image. 
 
 Select "Choose OS" and then "Use custom" to select the downloaded image file. Select your microSD card and flash.
 

--- a/source/docs/installation/sw_install/snakeyes.rst
+++ b/source/docs/installation/sw_install/snakeyes.rst
@@ -16,6 +16,10 @@ For more detailed instructions on using Etcher, please see the `Etcher website <
 
 .. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to 1.18.11 will fix this issue.
 
+Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.org/software/>`_ to flash the image. 
+
+Select "Choose OS" and then "Use custom" to select the downloaded image file. Select your microSD card and flash.
+
 Final Steps
 -----------
 Insert the flashed microSD card into your Raspberry Pi and boot it up. The first boot may take a few minutes as the Pi expands the filesystem. Be sure not to unplug during this process.

--- a/source/docs/installation/sw_install/snakeyes.rst
+++ b/source/docs/installation/sw_install/snakeyes.rst
@@ -16,7 +16,7 @@ For more detailed instructions on using Etcher, please see the `Etcher website <
 
 .. warning:: Using a version of Balena Etcher older than 1.18.11 may cause bootlooping (the system will repeatedly boot and restart) when imaging your Raspberry Pi. Updating to 1.18.11 will fix this issue.
 
-Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.com/software/>`_ to flash the image. 
+Alternatively, you can use the `Raspberry Pi Imager <https://www.raspberrypi.com/software/>`_ to flash the image.
 
 Select "Choose OS" and then "Use custom" to select the downloaded image file. Select your microSD card and flash.
 

--- a/source/docs/pipelines/output.rst
+++ b/source/docs/pipelines/output.rst
@@ -13,7 +13,7 @@ This section also includes a switch to enable processing and sending multiple ta
 .. raw:: html
 
         <video width="85%" controls>
-            <source src="../../../_static/assets/offsetandmultiple.mp4" type="video/mp4">
+            <source src="../../_static/assets/offsetandmultiple.mp4" type="video/mp4">
             Your browser does not support the video tag.
         </video>
 


### PR DESCRIPTION
Update links to balena etcher to point to 1.18.11 and change the warning against older versions to only warn against versions older than 1.18.11, as it is not the newest version.