### PR TITLE
Specify MrCal JNI Dependencies if JNI doesn't load on Linux

### DIFF
--- a/source/docs/installation/sw_install/linux-pc.rst
+++ b/source/docs/installation/sw_install/linux-pc.rst
@@ -55,11 +55,17 @@ If running an arm64 or architecture, you will need to add the following to your 
     deb [trusted=yes] http://mrcal.secretsauce.net/packages/DISTRO/public/ DISTRO main
 
 Where `DISTRO` is one of:
+
 - buster
+
 - bulleye
+
 - bookworm
+
 - bionic
+
 - focal
+
 - jammy
 
 .. note::

--- a/source/docs/installation/sw_install/linux-pc.rst
+++ b/source/docs/installation/sw_install/linux-pc.rst
@@ -39,3 +39,29 @@ If your computer has a compatible webcam connected, PhotonVision should startup 
 Accessing the PhotonVision Interface
 ------------------------------------
 Once the Java backend is up and running, you can access the main vision interface by navigating to ``localhost:5800`` inside your browser.
+
+MrCal JNI Error
+---------------
+If you run into an issue running PhotonVision on Linux where it cannot load the MrCal JNI, you may need to install dependencies with the following command:
+
+.. code-block::
+
+    $ sudo apt install mrcal libmrcal-dev python3-mrcal
+
+If running an arm64 or architecture, you will need to add the following to your `/etc/apt/sources.list`
+
+.. code-block::
+
+    deb [trusted=yes] http://mrcal.secretsauce.net/packages/DISTRO/public/ DISTRO main
+
+Where `DISTRO` is one of:
+- buster
+- bulleye
+- bookworm
+- bionic
+- focal
+- jammy
+
+.. note::
+
+    Further information can be found at https://mrcal.secretsauce.net/install.html


### PR DESCRIPTION
This would only apply if the user does not follow the [install script for Debian coprocessors](http://localhost:8000/html/docs/installation/sw_install/other-coprocessors.html#installing-photonvision). 

If the user is trying to run a development build without running PhotonVision as a service, they will need to install the MrCal dependencies manually for the MrCal JNI to load.